### PR TITLE
fix: added explicit dependency to PublicLoadBalancer to prevent flaky CFN deploy error

### DIFF
--- a/setup/Cluster-ECS-EC2-2AZ-ALB-1NAT.yaml
+++ b/setup/Cluster-ECS-EC2-2AZ-ALB-1NAT.yaml
@@ -323,6 +323,7 @@ Resources:
             IpProtocol: -1
 
   PublicLoadBalancer:
+    DependsOn: GatewayAttachment
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Scheme: internet-facing


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Added DependsOn statement to Cluster-ECS-EC2-2AZ-ALB-1NAT.yaml to prevent deployment errors when public load balancer is created before IG attachment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
