### PR TITLE
Pull from ECR public for base images due to Dockerhub throttling

### DIFF
--- a/app/hello-server/Dockerfile
+++ b/app/hello-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:buster-slim
+FROM public.ecr.aws/docker/library/node:buster-slim
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install

--- a/app/simple-server/Dockerfile
+++ b/app/simple-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:buster-slim
+FROM public.ecr.aws/docker/library/node:buster-slim
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
*Description of changes:* After successive builds of the example app via CodeBuild, Dockerhub throttling can kick in preventing the `docker build` from succeeding.  This change is to change the Dockerfiles to pull from ECR public which should provide higher limits.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
