### PR TITLE
updating ecr login command

### DIFF
--- a/lab-1/buildspec-hello-server.yml
+++ b/lab-1/buildspec-hello-server.yml
@@ -5,10 +5,10 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - aws --version
-      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
       - REPOSITORY_URI=<IMAGE_REPO_URI>
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $REPOSITORY_URI
   build:
     commands:
       - echo Build started on `date`

--- a/lab-1/buildspec.yml
+++ b/lab-1/buildspec.yml
@@ -8,10 +8,10 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - aws --version
-      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
       - REPOSITORY_URI=<IMAGE_REPO_URI>
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $REPOSITORY_URI
   build:
     commands:
       - echo Build started on `date`


### PR DESCRIPTION
*Issue #, if available:* #5

*Description of changes:*

Updated the aws ecr login command as `aws ecr get-login` was deprecated in awscli v2. See Note on cli reference page: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
